### PR TITLE
Reproducible on Binder

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,6 @@
+dependencies:
+  - python=3.7
+  - pip
+  - pip:
+    - -r requirements.txt
+

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,4 @@
 econ-ark==0.10.7
 numpy==1.19.2
-voila==0.2.2
 matplotlib==3.3.2
 ipywidgets==7.5.1


### PR DESCRIPTION
I added an `environment.yml` file to create working environments via conda and on Binder. Additionally `voila` was preventing a functioning binder build as it directly conflicted with the jupyter server requirement, ultimately leading to a 404 Error after a successful build of the docker image on mybinder.org.

This PR fixes the above issue.